### PR TITLE
Create Odyssey template

### DIFF
--- a/src/templates/default.json
+++ b/src/templates/default.json
@@ -1,35 +1,34 @@
 {
-  "title": "Default",
-  "name": "default",
+  "title": "Odyssey Template",
+  "name": "odyssey-template",
   "version": "2.0.0",
-  "description": "Provides a simple User authentication system.",
+  "description": "Provides the default Odyssey backbone for all US states.",
+  "preview": {
+    "url": "https://formio.github.io/formio-app-formio/dist",
+    "repo": "https://github.com/formio/formio-app-formio"
+  },
   "roles": {
     "administrator": {
       "title": "Administrator",
       "description": "A role for Administrative Users.",
-      "admin": true,
-      "default": false
+      "admin": true
     },
-    "authenticated": {
-      "title": "Authenticated",
-      "description": "A role for Authenticated Users.",
-      "admin": false,
-      "default": false
+    "guardian": {
+      "title": "Guardian",
+      "description": "A role for Guardian Users."
     },
     "anonymous": {
       "title": "Anonymous",
       "description": "A role for Anonymous Users.",
-      "admin": false,
       "default": true
     }
   },
   "resources": {
-    "user": {
-      "title": "User",
+    "guardian": {
+      "title": "Guardian",
       "type": "resource",
-      "name": "user",
-      "path": "user",
-      "tags": [],
+      "name": "guardian",
+      "path": "guardian",
       "submissionAccess": [
         {
           "type": "create_all",
@@ -69,7 +68,7 @@
           "type": "read_all",
           "roles": [
             "anonymous",
-            "authenticated",
+            "guardian",
             "administrator"
           ]
         }
@@ -78,8 +77,7 @@
         {
           "type": "email",
           "persistent": true,
-          "unique": true,
-          "required": true,
+          "unique": false,
           "protected": false,
           "defaultValue": "",
           "suffix": "",
@@ -125,7 +123,6 @@
       "type": "resource",
       "name": "admin",
       "path": "admin",
-      "tags": [],
       "submissionAccess": [
         {
           "type": "create_all",
@@ -165,7 +162,7 @@
           "type": "read_all",
           "roles": [
             "anonymous",
-            "authenticated",
+            "guardian",
             "administrator"
           ]
         }
@@ -174,8 +171,7 @@
         {
           "type": "email",
           "persistent": true,
-          "unique": true,
-          "required": true,
+          "unique": false,
           "protected": false,
           "defaultValue": "",
           "suffix": "",
@@ -219,11 +215,10 @@
   },
   "forms": {
     "userLogin": {
-      "title": "User Login",
+      "title": "Admin Login",
       "type": "form",
       "name": "userLogin",
       "path": "user/login",
-      "tags": [],
       "access": [
         {
           "type": "read_all",
@@ -283,22 +278,85 @@
         }
       ]
     },
-    "userRegister": {
-      "title": "User Register",
-      "name": "userRegister",
-      "path": "user/register",
+    "guardianLogin": {
+      "title": "Guardian Login",
       "type": "form",
-      "tags": [],
+      "name": "guardianLogin",
+      "path": "guardian/login",
       "access": [
         {
           "type": "read_all",
-          "roles": ["anonymous"]
+          "roles": ["administrator"]
+        }
+      ],
+      "submissionAccess": [
+        {
+          "type" : "create_own",
+          "roles" : ["administrator"]
+        }
+      ],
+      "components": [
+        {
+          "type": "email",
+          "persistent": true,
+          "unique": false,
+          "protected": false,
+          "defaultValue": "",
+          "suffix": "",
+          "prefix": "",
+          "placeholder": "Enter your email address",
+          "key": "email",
+          "lockKey": true,
+          "label": "Email",
+          "inputType": "email",
+          "tableView": true,
+          "input": true
+        },
+        {
+          "type": "password",
+          "persistent": true,
+          "protected": true,
+          "suffix": "",
+          "prefix": "",
+          "placeholder": "Enter your password.",
+          "key": "password",
+          "lockKey": true,
+          "label": "Password",
+          "inputType": "password",
+          "tableView": false,
+          "input": true
+        },
+        {
+          "type": "button",
+          "theme": "primary",
+          "disableOnInvalid": true,
+          "action": "submit",
+          "block": false,
+          "rightIcon": "",
+          "leftIcon": "",
+          "size": "md",
+          "key": "submit",
+          "tableView": false,
+          "label": "Submit",
+          "input": true
+        }
+      ]
+    },
+    "guardianRegister": {
+      "title": "Guardian Register",
+      "name": "guardianRegister",
+      "path": "guardian/register",
+      "type": "form",
+      "access": [
+        {
+          "type": "read_all",
+          "roles": ["administrator"]
         }
       ],
       "submissionAccess": [
         {
           "type": "create_own",
-          "roles": ["anonymous"]
+          "roles": ["administrator"]
         }
       ],
       "components": [
@@ -346,96 +404,28 @@
           "type": "button"
         }
       ]
-    },
-    "adminLogin": {
-      "title": "Admin Login",
-      "type": "form",
-      "name": "adminLogin",
-      "path": "admin/login",
-      "tags": [],
-      "access": [
-        {
-          "type": "read_all",
-          "roles": ["anonymous"]
-        }
-      ],
-      "submissionAccess": [
-        {
-          "type" : "create_own",
-          "roles" : ["anonymous"]
-        }
-      ],
-      "components": [
-        {
-          "type": "email",
-          "persistent": true,
-          "unique": false,
-          "protected": false,
-          "defaultValue": "",
-          "suffix": "",
-          "prefix": "",
-          "placeholder": "Enter your email address",
-          "key": "email",
-          "lockKey": true,
-          "label": "Email",
-          "inputType": "email",
-          "tableView": true,
-          "input": true
-        },
-        {
-          "type": "password",
-          "persistent": true,
-          "protected": true,
-          "suffix": "",
-          "prefix": "",
-          "placeholder": "Enter your password.",
-          "key": "password",
-          "lockKey": true,
-          "label": "Password",
-          "inputType": "password",
-          "tableView": false,
-          "input": true
-        },
-        {
-          "type": "button",
-          "theme": "primary",
-          "disableOnInvalid": true,
-          "action": "submit",
-          "block": false,
-          "rightIcon": "",
-          "leftIcon": "",
-          "size": "md",
-          "key": "submit",
-          "tableView": false,
-          "label": "Submit",
-          "input": true
-        }
-      ]
     }
   },
   "actions": {
-    "user:role": {
-      "title": "Role Assignment",
-      "name": "role",
-      "priority": 1,
-      "handler": ["after"],
-      "method": ["create"],
-      "form": "user",
-      "settings": {
-        "association": "new",
-        "type": "add",
-        "role": "authenticated"
-      }
-    },
-    "user:save": {
+    "guardianSave": {
       "title": "Save Submission",
       "name": "save",
-      "form": "user",
+      "form": "guardian",
       "handler": ["before"],
       "method": ["create", "update"],
-      "priority": 10
+      "priority": 11,
+      "settings": {}
     },
-    "userLogin:login": {
+    "adminSave": {
+      "title": "Save Submission",
+      "name": "save",
+      "form": "admin",
+      "handler": ["before"],
+      "method": ["create", "update"],
+      "priority": 11,
+      "settings": {}
+    },
+    "userLogin": {
       "name": "login",
       "title": "Login",
       "form": "userLogin",
@@ -443,104 +433,64 @@
       "method": ["create"],
       "handler": ["before"],
       "settings": {
-        "resources": ["user"],
+        "resources": ["admin"],
         "username": "email",
-        "password": "password",
-        "allowedAttempts": 5,
-        "attemptWindow": 30,
-        "lockWait": 1800
+        "password": "password"
       }
     },
-    "userRegister:save": {
+    "guardianRegisterSave": {
       "title": "Save Submission",
       "name": "save",
-      "form": "userRegister",
+      "form": "guardianRegister",
       "handler": ["before"],
-      "method": ["create", "update"],
-      "priority": 11,
+      "method": ["create"],
+      "priority": 10,
       "settings": {
-        "resource": "user",
+        "resource": "guardian",
         "fields": {
           "email": "email",
           "password": "password"
         }
       }
     },
-    "userRegister:login": {
+    "guardianRegisterLogin": {
       "name": "login",
       "title": "Login",
-      "form": "userRegister",
+      "form": "guardianRegister",
       "priority": 2,
       "method": ["create"],
       "handler": ["before"],
       "settings": {
-        "resources": ["user"],
+        "resources": ["guardian"],
         "username": "email",
         "password": "password"
       }
     },
-    "admin:role": {
-      "title": "Role Assignment",
+    "guardianRole": {
       "name": "role",
+      "title": "Role Assignment",
+      "form": "guardian",
       "priority": 1,
       "handler": ["after"],
       "method": ["create"],
-      "form": "admin",
       "settings": {
-        "association": "new",
+        "role": "guardian",
         "type": "add",
-        "role": "administrator"
+        "association": "new"
       }
     },
-    "admin:save": {
-      "title": "Save Submission",
-      "name": "save",
+    "adminRole": {
+      "name": "role",
+      "title": "Role Assignment",
       "form": "admin",
-      "handler": ["before"],
-      "method": ["create", "update"],
-      "priority": 10
-    },
-    "adminLogin:login": {
-      "name": "login",
-      "title": "Login",
-      "form": "adminLogin",
-      "priority": 2,
+      "priority": 1,
+      "handler": ["after"],
       "method": ["create"],
-      "handler": ["before"],
       "settings": {
-        "resources": ["admin"],
-        "username": "email",
-        "password": "password",
-        "allowedAttempts": 5,
-        "attemptWindow": 30,
-        "lockWait": 1800
+        "role": "administrator",
+        "type": "add",
+        "association": "new"
       }
     }
-  },
-  "access": [
-    {
-      "type": "create_all",
-      "roles": [
-        "administrator"
-      ]
-    },
-    {
-      "type": "read_all",
-      "roles": [
-        "administrator"
-      ]
-    },
-    {
-      "type": "update_all",
-      "roles": [
-        "administrator"
-      ]
-    },
-    {
-      "type": "delete_all",
-      "roles": [
-        "administrator"
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
This pull request changes `src/template/default.json` with the default template we will use for all Odyssey states. It sets up the basic resources, forms, permissions, and actions we will use according to the [notion](https://www.notion.so/primary-class/Form-io-Research-78ceabe47d294f48ba9800bb84f31b26#e09b91f86ae2463aa841daaf8088e9ec) document. The final goal is to hook the template to the default container.

> Note that the template does not create any Household Application forms, since that is the part that varies between states.

Running `docker-compose up` creates a `client` folder that is ignored by git. That folder, after being created, has a `project.json` file (not sure where it comes from), which is used to create the Mongo database in case it's not already created.

Knowing that information, we can copy our template (`src/templates/default.json`) to `client/project.json` before spinning up the container, which creates the Mongo database with Odyssey data instead of the default data. 

This PR aims to apply the JSON template on `docker-compose up` **and make the container setup automatic**. While we don't figure that out, here's how I'm applying the template:

```rb
docker-compose up # Creates the client folder with project.json
docker-compose down --volumes # Teardown Mongo DB that uses the default project.json
cp -f src/templates/default.json client/dist/project.json
docker-compose up # Will recreate mongo DB data using our template
```

Docs are poor, so I'm still figuring out the best way to do that and set up our template from the get-go when spinning up the container.

## Hints

The docker container has `node main` as its entrypoint. It looks like that command also creates the `client` folder through an `install.js` file. I suggest further investigating how we can make the template setup automatic and what "install" options are available for us.